### PR TITLE
automation: Use coverage-3

### DIFF
--- a/automation/run-checks.sh
+++ b/automation/run-checks.sh
@@ -138,7 +138,7 @@ if ! rpm -q testpackage1 2>&1 | grep 'testpackage1-1.0.1'; then
 	exit 1
 fi
 
-coverage combine --rcfile="${PWD}/automation/coverage.rc"
-coverage html -d exported-artifacts/coverage_html_report --rcfile="${PWD}/automation/coverage.rc"
+coverage-3 combine --rcfile="${PWD}/automation/coverage.rc"
+coverage-3 html -d exported-artifacts/coverage_html_report --rcfile="${PWD}/automation/coverage.rc"
 cp automation/index.html exported-artifacts/
 


### PR DESCRIPTION
It seems like python3-coverage from Appstream, unlike the one we had
from copr sbonazzo/EL8_collection, does not provide a '/usr/bin/coverage'
executable, only a 'coverage-3' one. Use that one, for now.

Change-Id: I0bd0597b3385049e68223e5c83606f387ad0a90d
Signed-off-by: Yedidyah Bar David <didi@redhat.com>