### PR TITLE
distro: Fix for rhel

### DIFF
--- a/src/otopi/packager.py
+++ b/src/otopi/packager.py
@@ -39,6 +39,7 @@ def ok_to_use_dnf():
                 'redhat',
                 'centos',
                 'ibm_powerkvm',
+                'rhel',
             ) and
             version >= '8'
         )

--- a/src/plugins/otopi/network/iptables.py
+++ b/src/plugins/otopi/network/iptables.py
@@ -58,6 +58,7 @@ class Plugin(plugin.PluginBase):
             'fedora',
             'centos',
             'ibm_powerkvm',
+            'rhel',
         ):
             self.logger.warning(
                 _('Unsupported distribution for iptables plugin')


### PR DESCRIPTION
A recent patch to use python's distro module instead of platform breaks
on rhel. Fix that.

Change-Id: I298592396db21b0aff3cf913a88f4d8161703a1d
Signed-off-by: Yedidyah Bar David <didi@redhat.com>