### PR TITLE
minidnf: checkForSafeUpdate: Return all data

### DIFF
--- a/src/otopi/minidnf.py
+++ b/src/otopi/minidnf.py
@@ -938,7 +938,7 @@ class MiniDNF():
                 upgradeAvailable = True
 
                 for p in self.queryTransaction():
-                    plist.append((p['display_name'], p['operation']))
+                    plist.append(p.copy())
 
                 # Verify all installed packages available in repos
                 for package in self.queryTransaction():


### PR DESCRIPTION
In plist, instead of returning only display_name and operation, return
all the data we received from queryTransaction, which is:
arch display_name epoch name operation release version.

There is right now no external user of checkForSafeUpdate, other than
engine-setup in a still-pending patch, so we do not risk breaking
anything.

Change-Id: I51245cb98eca436dc95ad675464193a7dadaa7d3
Related-To: https://bugzilla.redhat.com/2024157
Signed-off-by: Yedidyah Bar David <didi@redhat.com>