### PR TITLE
dialog: human: Allow confirmation via answer file

### DIFF
--- a/src/plugins/otopi/dialog/human.py
+++ b/src/plugins/otopi/dialog/human.py
@@ -297,11 +297,11 @@ class Plugin(plugin.PluginBase, dialog.DialogBaseImpl):
             ).format(
                 description=description,
             )
-        self.dialog.note(
-            text=note,
+        value = self.dialog.queryString(
+            name=f'DIALOG_CONFIRM/{name}',
+            note=note,
             prompt=prompt,
         )
-        value = self._readline()
         ret = value in ('yes', 'y', 'Y')
         return ret
 


### PR DESCRIPTION
The dialog classes have a little-used method called 'confirm'.
In the patches for adding answer-file support, 'confirm' wasn't handled.
Do this now, simply by replacing the internal implementation with a call
to queryString.

Change-Id: I6a7522b26b7bb0ecdf94440403cb54f262ac77f9
Signed-off-by: Yedidyah Bar David <didi@redhat.com>