### PR TITLE
minidnf: Log calls to _plugins._unload()

### DIFF
--- a/src/otopi/minidnf.py
+++ b/src/otopi/minidnf.py
@@ -411,6 +411,7 @@ class MiniDNF():
 
     def _destroyBase(self, base):
         if base is not None:
+            self._sink.verbose(_('Calling _plugins._unload'))
             base._plugins._unload()
             base.close()
 


### PR DESCRIPTION
_plugins._unload() is a private method, not part of the dnf API.
Log calls to it, so that we can estimate how important it is to use a
public API, once available.

Change-Id: Ifa9ba432ab2a9e9ffe5d0d2e8fa1622b40ec5342
Related-To: https://bugzilla.redhat.com/1542492
Signed-off-by: Yedidyah Bar David <didi@redhat.com>