### PR TITLE
packager: Support any rhel- or fedora-like distribution

### DIFF
--- a/src/otopi/packager.py
+++ b/src/otopi/packager.py
@@ -28,22 +28,8 @@ def ok_to_use_dnf():
     if os.environ.get(constants.SystemEnvironment.DNF_ENABLE):
         return True
 
-    plat_dist = distro.linux_distribution(full_distribution_name=0)
-    distribution = plat_dist[0]
-    version = plat_dist[1]
-    return (
-        distribution in (
-            'fedora',
-        ) or (
-            distribution in (
-                'redhat',
-                'centos',
-                'ibm_powerkvm',
-                'rhel',
-            ) and
-            version >= '8'
-        )
-    )
+    id_and_like = [distro.id()] + distro.like().split(' ')
+    return any(dist in id_and_like for dist in ('rhel', 'fedora'))
 
 
 @util.export


### PR DESCRIPTION
Implicitly support all RHEL rebuilds, such as AlmaLinux, instead of
hard-coding them.

New code is copied from ovirt-engine's
packaging/setup/ovirt_engine_setup/util.py:
is_ovirt_packaging_supported_distro .

Dropping the check for version (>=8) - it's not needed, as we do not
build otopi anymore for el7.

Change-Id: Iea33ed723b24910f5fef7f6288dd73bbe11ac116
Bug-Url: https://bugzilla.redhat.com/2060006
Signed-off-by: Yedidyah Bar David <didi@redhat.com>