### PR TITLE
build: On github, use PR commit as suffix

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -46,7 +46,7 @@ jobs:
       run: mkdir -p tmp.repos
 
     - name: rpmbuild
-      run: rpmbuild -D "_topdir $PWD/tmp.repos" -D "release_suffix .$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)" -ta otopi-*.tar.gz
+      run: rpmbuild -D "_topdir $PWD/tmp.repos" -D "release_suffix .$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" -ta otopi-*.tar.gz
 
     - name: Collect artifacts
       run: |


### PR DESCRIPTION
This is a much simpler alternative to
https://github.com/oVirt/otopi/pull/23 .

Change-Id: Icc3d3d52322d7204c6ca8b70c0b9318cc8daf5ec
Signed-off-by: Yedidyah Bar David <didi@redhat.com>