### PR TITLE
github: Build from the pushed commit

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: autopoint
       run: autopoint


### PR DESCRIPTION
Do not merge/rebase, so that the git hash in the generated RPM's names
matches the hash of the commit we build from. By default, the checkout
action merges with HEAD, generating an ad-hoc hash that's discarded
after the build and can't be found anywhere, making it very hard to find
out which commit was used to build a particular RPM.

See also:

https://github.com/marketplace/actions/checkout?version=v2.4.2#checkout-pull-request-head-commit-instead-of-merge-commit

https://lists.ovirt.org/archives/list/devel@ovirt.org/thread/7SEFKOASOATTMO2NK2SBWMOV4CV6LZOS/

Change-Id: Idf4dad88c028f1664b55314a34a9f798c9b1a23d
Signed-off-by: Yedidyah Bar David <didi@redhat.com>