### PR TITLE
build fix: Bump to 1.10.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 otopi -- oVirt Task Oriented Pluggable Installer/Implementation
 
-????-??-?? - Version 1.10.1
+????-??-?? - Version 1.10.2
 
 2022-03-03 - Version 1.10.0
  * packager: Support any rhel- or fedora-like distribution

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ(2.60)
 
 define([VERSION_MAJOR], [1])
 define([VERSION_MINOR], [10])
-define([VERSION_FIX], [1])
+define([VERSION_FIX], [2])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
 define([VERSION_SUFFIX], [_master])
 


### PR DESCRIPTION
1.10.1 was never released, but we already accidentally built (in copr,
from master HEAD) 1.10.1-1.something. Later we lowered the release to
0.something, so that we build 1.10.1-0.something, so these newer builds
are considered (by dnf/rpm) older than the
already-built-and-available-from-copr 1.10.1-1.something.

Fix this by bumping to 1.10.2, keeping the release 0.something until the
next release.

This also means that we'll never release 1.10.1.

Change-Id: Ie37c7ff6a9d644d06ca83a88b7cf675eaed3f5b4
Signed-off-by: Yedidyah Bar David <didi@redhat.com>