### PR TITLE
core: Filter out secret questions' answers

### DIFF
--- a/src/otopi/constants.py
+++ b/src/otopi/constants.py
@@ -124,6 +124,8 @@ class CoreEnv(object):
     LOG_FILTER = 'CORE/logFilter'
     LOG_FILTER_RE = 'CORE/logFilterRe'
     LOG_FILTER_KEYS = 'CORE/logFilterKeys'
+    LOG_FILTER_QUESTIONS = 'CORE/logFilterQuestions'
+    LOG_FILTER_QUESTIONS_KEYS = 'CORE/logFilterQuestionsKeys'
     LOG_FILE_HANDLE = 'CORE/logFileHandle'
     LOG_REMOVE_AT_EXIT = 'CORE/logRemoveAtExit'
     CONFIG_FILE_NAME = 'CORE/configFileName'

--- a/src/plugins/otopi/core/config.py
+++ b/src/plugins/otopi/core/config.py
@@ -65,6 +65,20 @@ class Plugin(plugin.PluginBase):
                     self.environment[name] = value
                 else:
                     self.environment.setdefault(name, value)
+                if name not in self.environment[
+                    constants.CoreEnv.LOG_FILTER_QUESTIONS_KEYS
+                ]:
+                    if (
+                        name.startswith(
+                            constants.CoreEnv.QUESTION_PREFIX
+                        ) and
+                        name.split('/')[-1] in self.environment[
+                            constants.CoreEnv.LOG_FILTER_QUESTIONS
+                        ]
+                    ):
+                        self.environment[
+                            constants.CoreEnv.LOG_FILTER_QUESTIONS_KEYS
+                        ].add(name)
 
     def __init__(self, context):
         super(Plugin, self).__init__(context=context)

--- a/src/plugins/otopi/core/log.py
+++ b/src/plugins/otopi/core/log.py
@@ -192,7 +192,10 @@ class Plugin(plugin.PluginBase):
                     self.environment[constants.CoreEnv.LOG_FILTER]._list +
                     [
                         self.environment.get(k, None) for k in
-                        self.environment[constants.CoreEnv.LOG_FILTER_KEYS]
+                        self.environment[constants.CoreEnv.LOG_FILTER_KEYS] +
+                        list(self.environment[
+                            constants.CoreEnv.LOG_FILTER_QUESTIONS_KEYS
+                        ])
                     ]
                 ),
                 regexps=self.environment[constants.CoreEnv.LOG_FILTER_RE],
@@ -203,12 +206,33 @@ class Plugin(plugin.PluginBase):
         self._handler = None
         self._logerror = None
         self.environment[constants.CoreEnv.LOG_FILTER_KEYS] = []
+        self.environment[constants.CoreEnv.LOG_FILTER_RE] = []
+        self.environment[constants.CoreEnv.LOG_FILTER_QUESTIONS] = []
+        self.environment[constants.CoreEnv.LOG_FILTER_QUESTIONS_KEYS] = set([
+            k for k in self.environment.keys()
+            if k.startswith(constants.CoreEnv.QUESTION_PREFIX) and
+            # E.g. QUESTION/2/OVESETUP_CONFIG_ADMIN_SETUP
+            k.split('/')[-1] in self.environment[
+                constants.CoreEnv.LOG_FILTER_QUESTIONS
+            ]
+        ])
         self._filtered_keys_at_setup = []
 
     def _setupLogging(self):
         self.environment[constants.CoreEnv.LOG_FILE_HANDLE] = None
         self.environment[constants.CoreEnv.LOG_FILTER] = self._MyLoggerFilter()
-        self.environment[constants.CoreEnv.LOG_FILTER_RE] = []
+        for k in self.environment.keys():
+            if (
+                k.startswith(constants.CoreEnv.QUESTION_PREFIX) and
+                # E.g. QUESTION/2/OVESETUP_CONFIG_ADMIN_SETUP
+                k.split('/')[-1] in self.environment[
+                    constants.CoreEnv.LOG_FILTER_QUESTIONS
+                ]
+            ):
+                self.environment[
+                    constants.CoreEnv.LOG_FILTER_QUESTIONS_KEYS
+                ].add(k)
+
         self.environment[
             constants.CoreEnv.LOG_FILTER_RE
         ].append(


### PR DESCRIPTION
Add support for env[LOG_FILTER_QUESTIONS] - questions names' for which
the answers are filtered out from logs.

It's initialized to an empty list.

It's used only in Stages.CORE_LOG_INIT, so questions should be added to
it beforehand. This isn't a real limitation, because otherwise we risk
logging the answers anyway.

It's added for engine-setup which will use it in its own patch.

Change-Id: I3feb99aa920aa552081ea0763545d75feb017c34
Signed-off-by: Yedidyah Bar David <didi@redhat.com>