### PR TITLE
dialog: human: Fix wrapping notes

### DIFF
--- a/src/otopi/dialog.py
+++ b/src/otopi/dialog.py
@@ -266,10 +266,17 @@ class DialogBaseImpl(DialogBase):
                 self.__flush(self.__output)
 
     def _output_terminal_width(self):
+        res = 80
         try:
-            return os.get_terminal_size(self.__output.fileno()).columns
+            res = os.get_terminal_size(self.__output.fileno()).columns
         except OSError:
-            return 80
+            pass
+        if res == 0:
+            try:
+                res = int(os.environ.get('COLUMNS', res))
+            except Exception:
+                pass
+        return res
 
     def _queryStringNote(
         self,

--- a/src/plugins/otopi/dialog/human.py
+++ b/src/plugins/otopi/dialog/human.py
@@ -140,7 +140,7 @@ class Plugin(plugin.PluginBase, dialog.DialogBaseImpl):
             text = '\n'
         text = common.toStr(text)
 
-        width = self._output_terminal_width() - 16
+        width = max(self._output_terminal_width() - 16, 1)
 
         lines = []
         for non_wrapped_line in text.splitlines():


### PR DESCRIPTION
emacs shell buffers do return a terminal width, of 0. This fails with:
```
  File "/usr/lib64/python3.6/textwrap.py", line 248, in _wrap_chunks
    raise ValueError("invalid width %r (must be > 0)" % self.width)
ValueError: invalid width -16 (must be > 0)
```
Fix this:

- If os.get_terminal_size returns 0, default to the environment variable
COLUMNS, if set, and to 80, otherwise. Please note that on recent
systems, bash's COLUMNS variable is not exported to sub-processes,
including bash scripts.

- Make eventual width at least 1.

Change-Id: I2574c19c1585675035d6ebd19a5711281b942a7c
Signed-off-by: Yedidyah Bar David <didi@redhat.com>