### PR TITLE
copr: Fix quoting in setting SUFFIX

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -18,7 +18,7 @@ prepare: installdeps git_config_pre
 	./configure
 
 srpm: installdeps git_config_pre prepare
-	$(eval SUFFIX=$(shell sh -c " . automation/config.sh; [ -n "$${RELEASE_SUFFIX}" ] && echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
+	$(eval SUFFIX=$(shell sh -c ' . automation/config.sh; [ -n "$${RELEASE_SUFFIX}" ] && echo ".$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)"'))
 	mkdir -p tmp.repos
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
 	sed "s:%{?release_suffix}:${SUFFIX}:" -i otopi.spec.in


### PR DESCRIPTION
Again. Sigh.

This time, verify both after a release build and after a post-release
build...

Next time this breaks I'll replace it with a shell script. Debugging
both shell syntax, Make syntax, and Make eval, is becoming too much.

Change-Id: Ib670b35f5439fb4d5ee57d68c22e25a3f3e22a0c
Signed-off-by: Yedidyah Bar David <didi@redhat.com>